### PR TITLE
Add tests for classes that declare properties as new, instead of override

### DIFF
--- a/TestAssemblies/AssemblyWithInheritance/Classes.cs
+++ b/TestAssemblies/AssemblyWithInheritance/Classes.cs
@@ -132,6 +132,44 @@ public class DerivedNoOverrides : BaseClass
     }
 }
 
+public class DerivedNewProperties : BaseClass
+{
+    public new int Property1 { get; set; }
+    public override int Property3 { get; set; }
+
+    public int Property5 => Property1 - Property3 + Property2;
+
+    void OnProperty1Changed()
+    {
+        ReportOnChanged();
+    }
+
+    void OnProperty2Changed()
+    {
+        ReportOnChanged();
+    }
+
+    void OnProperty3Changed()
+    {
+        ReportOnChanged();
+    }
+
+    void OnProperty4Changed()
+    {
+        ReportOnChanged();
+    }
+
+    void OnProperty5Changed()
+    {
+        ReportOnChanged();
+    }
+
+    void ReportOnChanged([CallerMemberName] string callerMemberName = null)
+    {
+        Notifications.Add("derived:" + callerMemberName);
+    }
+}
+
 public class DerivedDerivedClass : DerivedClass
 {
     public override int Property1

--- a/Tests/AssemblyWithInheritanceTests.cs
+++ b/Tests/AssemblyWithInheritanceTests.cs
@@ -50,6 +50,9 @@ public class AssemblyWithInheritanceTests
     [InlineData(1, "DerivedNoOverrides", "Property3", new[] { "Property5", "derived:OnProperty3Changed", "Property3" })]
     [InlineData(0, "PocoBase", "Property1", new string[0])]
     [InlineData(0, "DerivedFromPoco", "Property1", new[] { "Property4", "derived:OnProperty1Changed", "Property1" })]
+    [InlineData(0, "DerivedNewProperties", "Property1", new[] { "Property5", "derived:OnProperty1Changed", "Property1" })]
+    [InlineData(0, "DerivedNewProperties", "Property2", new[] { "Property4", "base:OnProperty2Changed", "Property2" })]
+    [InlineData(0, "DerivedNewProperties", "Property3", new[] { "Property5", "derived:OnProperty3Changed", "Property3" })]
     public void DerivedClassRaisesAllExpectedEvents(int assemblyIndex, string className, string propertyName, string[] expected)
     {
         var assembly = assemblies[assemblyIndex];


### PR DESCRIPTION
This ports a few tests from my branch for 635 to this branch. The other tests I generated either appear to be either already covered, or are unwanted.